### PR TITLE
#164352866 Setup react routing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,25 @@
+{
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "jsx": true
+        }
+    },
+    "rules": {
+        "semi": "warn",
+        "indent": ["error", 4],
+        "linebreak-style": ["error", "unix"],
+        "quotes": ["error", "double"],
+        "comma-dangle": ["error", "always"],
+        "no-cond-assign": ["error", "always"],
+        "no-console": "off"
+    },
+    "env": {
+        "browser": true,
+        "node": true
+    },
+    "plugins": [
+        "eslint-plugin-react"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "./node_modules/.bin/webpack-dev-server --config ./webpack/webpack.config.js --hot --open"
+    "start": "./node_modules/.bin/webpack-dev-server --config ./webpack/webpack.config.js --hot --open",
+    "lint:fix": "eslint . --ignore-path .gitignore --fix"
   },
   "repository": "git@github.com:armstrongsouljah/storemanager-frontend.git",
   "author": "Muhwezi Armstrong <armstrongsouljah@gmail.com>",
@@ -15,6 +16,7 @@
     "less-loader": "^4.1.0",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
+    "react-router-dom": "^4.3.1",
     "style-loader": "^0.23.1"
   },
   "devDependencies": {
@@ -25,6 +27,8 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "babel-register": "^6.26.0",
+    "eslint": "^5.15.0",
+    "eslint-plugin-react": "^7.12.4",
     "html-webpack-plugin": "^3.2.0",
     "less": "^3.9.0",
     "webpack": "^4.29.6",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
-import React from 'react';
-import { render } from 'react-dom';
-import App from './views/App';
+import React from "react";
+import { render, } from "react-dom";
+import Routes from "./routes/index";
 
-
-render(<App />, document.querySelector('#root'));
+render(<Routes />, document.querySelector("#root"));

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { Route, BrowserRouter as Router, } from "react-router-dom";
+import App from "../views/App";
+
+const Routes = () => (
+    <Router>
+        <div>
+            <Route path='/' exact component={App} />
+            <Route path='/products' exact component={() => (<h1>Products page</h1>)} />
+        </div>
+    </Router> 
+);
+
+export default Routes;

--- a/src/views/App.jsx
+++ b/src/views/App.jsx
@@ -3,6 +3,10 @@ import React from 'react';
 const App = () => (
     <div>
         <h1>Welcome to store manager</h1>
+        <ul>
+            <li><a href="/products">Products</a></li>
+        </ul>
+        
     </div>
 );
 

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -1,42 +1,42 @@
-var webpack = require('webpack');
-var path = require('path');
-var HtmlWebpackPlugin = require('html-webpack-plugin');
+var webpack = require("webpack");
+var path = require("path");
+var HtmlWebpackPlugin = require("html-webpack-plugin");
 
 
-var parentDir = path.join(__dirname, '../src/');
+var parentDir = path.join(__dirname, "../src/");
 
 module.exports = {
     entry: [
-        path.join(parentDir, 'index.js')
+        path.join(parentDir, "index.js"),
     ],
     resolve: {
-        extensions: [".jsx", ".js"]
+        extensions: [".jsx", ".js",],
     },
-    mode: 'development',
+    mode: "development",
     module: {
         rules: [{
             test: /\.(js|jsx)$/,
-                exclude: /node_modules/,
-                loader: 'babel-loader'
-            },{
-                test: /\.less$/,
-                loaders: ["style-loader", "css-loder", "less-loader"]
-            }
-        ]
+            exclude: /node_modules/,
+            loader: "babel-loader",
+        },{
+            test: /\.less$/,
+            loaders: ["style-loader", "css-loder", "less-loader",],
+        },
+        ],
     },
     plugins: [
         new HtmlWebpackPlugin({
-            template: './src/index.html',
-            filename: './index.html',
-          }),
+            template: "./src/index.html",
+            filename: "./index.html",
+        }),
     ],
     output: {
-        path: parentDir + '/dist',
-        publicPath: '/',
-        filename: 'bundle.js'
+        path: parentDir + "/dist",
+        publicPath: "/",
+        filename: "bundle.js",
     },
     devServer: {
         contentBase: parentDir,
-        historyApiFallback: true
-    }
-}
+        historyApiFallback: true,
+    },
+};


### PR DESCRIPTION
#### What does this Pr do?
- Introduces an implementation to enable routing within our react application.

#### Description of the task to be done.
- install react router library
- setup dummy routes
- refactor entry file to render routes instead of root app component

#### How can this be manually tested?
- Fetch this branch to your local machine and checkout to it by running `git fetch origin ch-setup-routing-164352866 && git checkout ch-setup-routing-164352866`
- Install project dependencies by running `yarn`
- Start the development server by running `yarn start`
- Click on the products link on the home page and it should navigate to the `products page.`

#### What are the related pivotal stories?
[164352866](https://www.pivotaltracker.com/story/show/164352866)